### PR TITLE
Hexfärg

### DIFF
--- a/src/components/reuse/Color.tsx
+++ b/src/components/reuse/Color.tsx
@@ -59,12 +59,12 @@ export default function Color({ color }: Props, state: State) {
                 if (!is_hexadecimal(color.color)) {
                     setHex(color.color);
                 } else {
-                    setHex("#dcdcf5");
+                    setHex("#b2b2b2");
                 }
     }
 
     if (color.color == "" && hex === "" ) {
-        setHex("#dcdcf5");
+        setHex("#b2b2b2");
     }
 
     const ncs: string = formatNcs(color.colorCode)


### PR DESCRIPTION
- Om färgkoden inte är en NCS kod --> kolla om den har någon vald kulör -- > om den har det visas hexkoden --> om den inte har det visas en default kulör (just nu grå). 
- Om man inte har valt någon kulör i selecten när man skapar färg blir grå som default. Det är bara de gamla kulörerna som skapades innan selecten som påverkas av sista delen ovanför. 